### PR TITLE
Add initial handling for the knowledge base post type

### DIFF
--- a/articles/post-knowledge_base.php
+++ b/articles/post-knowledge_base.php
@@ -85,7 +85,12 @@ $post_share_placement = spine_get_option( 'post_social_placement' );
 		</div>
 	<?php endif; ?>
 
-	<?php comments_template(); ?>
+	<?php
+	// Display the comments template if the current user is logged in.
+	//if ( is_user_logged_in() ) {
+		comments_template();
+	//}
+	?>
 
 	<footer class="article-footer">
 

--- a/articles/post-knowledge_base.php
+++ b/articles/post-knowledge_base.php
@@ -85,12 +85,7 @@ $post_share_placement = spine_get_option( 'post_social_placement' );
 		</div>
 	<?php endif; ?>
 
-	<?php
-	// Display the comments template if the current user is logged in.
-	//if ( is_user_logged_in() ) {
-		comments_template();
-	//}
-	?>
+	<?php comments_template(); ?>
 
 	<footer class="article-footer">
 

--- a/articles/post-knowledge_base.php
+++ b/articles/post-knowledge_base.php
@@ -24,7 +24,7 @@ $post_share_placement = spine_get_option( 'post_social_placement' );
 		<?php endif; ?>
 		</hgroup>
 		<hgroup class="source">
-			<time class="article-date" datetime="<?php echo get_the_date( 'c' ); ?>"><?php echo get_the_date(); ?></time>
+			Last updated <time class="article-date" datetime="<?php echo esc_attr( get_the_modified_date( 'c' ) ); ?>"><?php echo esc_html( get_the_modified_date() ); ?></time>
 			<cite class="article-author">
 				<?php
 				if ( '1' === spine_get_option( 'show_author_page' ) ) {

--- a/articles/post-knowledge_base.php
+++ b/articles/post-knowledge_base.php
@@ -85,6 +85,8 @@ $post_share_placement = spine_get_option( 'post_social_placement' );
 		</div>
 	<?php endif; ?>
 
+	<?php comments_template(); ?>
+
 	<footer class="article-footer">
 
 		<?php

--- a/articles/post-knowledge_base.php
+++ b/articles/post-knowledge_base.php
@@ -5,8 +5,6 @@
  * @package sfs411
  */
 
-$post_share_placement = spine_get_option( 'post_social_placement' );
-
 ?>
 
 <article id="post-<?php the_ID(); ?>" <?php post_class(); ?>>

--- a/articles/post-knowledge_base.php
+++ b/articles/post-knowledge_base.php
@@ -35,12 +35,6 @@ $post_share_placement = spine_get_option( 'post_social_placement' );
 				?>
 			</cite>
 		</hgroup>
-
-		<?php
-		if ( is_singular() && in_array( $post_share_placement, array( 'top', 'both' ), true ) ) {
-			get_template_part( 'parts/share-tools' );
-		}
-		?>
 	</header>
 
 	<?php if ( ! is_singular() ) : ?>
@@ -91,10 +85,6 @@ $post_share_placement = spine_get_option( 'post_social_placement' );
 
 		<?php
 
-		if ( is_singular() && in_array( $post_share_placement, array( 'bottom', 'both' ), true ) ) {
-			get_template_part( 'parts/share-tools' );
-		}
-
 		// Display site level categories attached to the post.
 		if ( has_category() ) {
 			echo '<dl class="categorized">';
@@ -103,23 +93,6 @@ $post_share_placement = spine_get_option( 'post_social_placement' );
 				echo '<dd><a href="' . esc_url( get_category_link( $category->cat_ID ) ) . '">' . esc_html( $category->cat_name ) . '</a></dd>';
 			}
 			echo '</dl>';
-		}
-
-		// Display University categories attached to the post.
-		if ( taxonomy_exists( 'wsuwp_university_category' ) && has_term( '', 'wsuwp_university_category' ) ) {
-			$university_category_terms = get_the_terms( get_the_ID(), 'wsuwp_university_category' );
-			if ( ! is_wp_error( $university_category_terms ) ) {
-				echo '<dl class="university-categorized">';
-				echo '<dt><span class="university-categorized-default">Categorized</span></dt>';
-
-				foreach ( $university_category_terms as $uc_term ) {
-					$term_link = get_term_link( $uc_term->term_id, 'wsuwp_university_category' );
-					if ( ! is_wp_error( $term_link ) ) {
-						echo '<dd><a href="' . esc_url( $term_link ) . '">' . esc_html( $uc_term->name ) . '</a></dd>';
-					}
-				}
-				echo '</dl>';
-			}
 		}
 
 		// Display University tags attached to the post.
@@ -132,55 +105,7 @@ $post_share_placement = spine_get_option( 'post_social_placement' );
 			echo '</dl>';
 		}
 
-		// Display University locations attached to the post.
-		if ( taxonomy_exists( 'wsuwp_university_location' ) && has_term( '', 'wsuwp_university_location' ) ) {
-			$university_location_terms = get_the_terms( get_the_ID(), 'wsuwp_university_location' );
-			if ( ! is_wp_error( $university_location_terms ) ) {
-				echo '<dl class="university-location">';
-				echo '<dt><span class="university-location-default">Location</span></dt>';
-
-				foreach ( $university_location_terms as $ul_term ) {
-					$term_link = get_term_link( $ul_term->term_id, 'wsuwp_university_location' );
-					if ( ! is_wp_error( $term_link ) ) {
-						echo '<dd><a href="' . esc_url( $ul_term_link ) . '">' . esc_html( $ul_term->name ) . '</a></dd>';
-					}
-				}
-				echo '</dl>';
-			}
-		}
-
-		// If a user has filled out their description and this is a multi-author blog, show a bio on their entries.
-		if ( is_singular() && get_the_author_meta( 'description' ) && is_multi_author() ) : ?>
-		<div class="author-info">
-
-			<div class="author-avatar">
-				<?php
-				/** This filter is documented in author.php */
-				$author_bio_avatar_size = apply_filters( 'sfs411_author_bio_avatar_size', 68 );
-				echo get_avatar( get_the_author_meta( 'user_email' ), $author_bio_avatar_size );
-				?>
-			</div><!-- .author-avatar -->
-
-			<div class="author-description">
-				<h2><?php
-				/* translators: %s: author name */
-				printf( esc_html__( 'About %s', 'sfs411' ), get_the_author() );
-				?></h2>
-				<p><?php the_author_meta( 'description' ); ?></p>
-				<?php if ( '1' === spine_get_option( 'show_author_page' ) ) : ?>
-				<div class="author-link">
-					<a href="<?php echo esc_url( get_author_posts_url( get_the_author_meta( 'ID' ) ) ); ?>" rel="author">
-						<?php
-						/* translators: %s: author name */
-						printf( esc_html__( 'View all posts by %s', 'sfs411' ), get_the_author() );
-						?> <span class="meta-nav">&rarr;</span>
-					</a>
-				</div><!-- .author-link	-->
-				<?php endif; ?>
-			</div><!-- .author-description -->
-
-		</div><!-- .author-info -->
-	<?php endif; ?>
+		?>
 
 	</footer><!-- .entry-meta -->
 

--- a/articles/post-knowledge_base.php
+++ b/articles/post-knowledge_base.php
@@ -1,0 +1,185 @@
+<?php
+/**
+ * Template part for displaying a Knowledge Base post's content.
+ *
+ * @package sfs411
+ */
+
+$post_share_placement = spine_get_option( 'post_social_placement' );
+
+?>
+
+<article id="post-<?php the_ID(); ?>" <?php post_class(); ?>>
+
+	<header class="article-header">
+		<hgroup>
+		<?php if ( is_single() ) : ?>
+			<?php if ( true === spine_get_option( 'articletitle_show' ) ) : ?>
+				<h1 class="article-title"><?php the_title(); ?></h1>
+			<?php endif; ?>
+		<?php else : ?>
+			<h2 class="article-title">
+				<a href="<?php the_permalink(); ?>" rel="bookmark"><?php the_title(); ?></a>
+			</h2>
+		<?php endif; ?>
+		</hgroup>
+		<hgroup class="source">
+			<time class="article-date" datetime="<?php echo get_the_date( 'c' ); ?>"><?php echo get_the_date(); ?></time>
+			<cite class="article-author">
+				<?php
+				if ( '1' === spine_get_option( 'show_author_page' ) ) {
+					the_author_posts_link();
+				} else {
+					echo esc_html( get_the_author() );
+				}
+				?>
+			</cite>
+		</hgroup>
+
+		<?php
+		if ( is_singular() && in_array( $post_share_placement, array( 'top', 'both' ), true ) ) {
+			get_template_part( 'parts/share-tools' );
+		}
+		?>
+	</header>
+
+	<?php if ( ! is_singular() ) : ?>
+		<div class="article-summary">
+			<?php
+
+			if ( spine_has_thumbnail_image() ) {
+				?><figure class="article-thumbnail"><a href="<?php the_permalink(); ?>"><?php spine_the_thumbnail_image(); ?></a></figure><?php
+			} elseif ( spine_has_featured_image() ) {
+				?><figure class="article-thumbnail"><a href="<?php the_permalink(); ?>"><?php the_post_thumbnail( 'spine-thumbnail_size' ); ?></a></figure><?php
+			}
+
+			// If a manual excerpt is available, default to that. If `<!--more-->` exists in content, default
+			// to that. If an option is set specifically to display excerpts, default to that. Otherwise show
+			// full content.
+			if ( $post->post_excerpt ) {
+				echo wp_kses_post( get_the_excerpt() ) . ' <a href="' . esc_url( get_permalink() ) . '"><span class="excerpt-more-default">&raquo; More ...</span></a>';
+			} elseif ( strstr( $post->post_content, '<!--more-->' ) ) {
+				the_content( '<span class="content-more-default">&raquo; More ...</span>' );
+			} elseif ( 'excerpt' === spine_get_option( 'archive_content_display' ) ) {
+				the_excerpt();
+			} else {
+				the_content();
+			}
+
+			?>
+		</div><!-- .article-summary -->
+	<?php else : ?>
+		<div class="article-body">
+			<?php
+
+			the_content();
+
+			wp_link_pages(
+				array(
+					'before' => '<div class="page-links">' . __( 'Pages:', 'spine' ),
+					'after' => '</div>',
+				)
+			);
+
+			?>
+		</div>
+	<?php endif; ?>
+
+	<footer class="article-footer">
+
+		<?php
+
+		if ( is_singular() && in_array( $post_share_placement, array( 'bottom', 'both' ), true ) ) {
+			get_template_part( 'parts/share-tools' );
+		}
+
+		// Display site level categories attached to the post.
+		if ( has_category() ) {
+			echo '<dl class="categorized">';
+			echo '<dt><span class="categorized-default">Categorized</span></dt>';
+			foreach ( get_the_category() as $category ) {
+				echo '<dd><a href="' . esc_url( get_category_link( $category->cat_ID ) ) . '">' . esc_html( $category->cat_name ) . '</a></dd>';
+			}
+			echo '</dl>';
+		}
+
+		// Display University categories attached to the post.
+		if ( taxonomy_exists( 'wsuwp_university_category' ) && has_term( '', 'wsuwp_university_category' ) ) {
+			$university_category_terms = get_the_terms( get_the_ID(), 'wsuwp_university_category' );
+			if ( ! is_wp_error( $university_category_terms ) ) {
+				echo '<dl class="university-categorized">';
+				echo '<dt><span class="university-categorized-default">Categorized</span></dt>';
+
+				foreach ( $university_category_terms as $uc_term ) {
+					$term_link = get_term_link( $uc_term->term_id, 'wsuwp_university_category' );
+					if ( ! is_wp_error( $term_link ) ) {
+						echo '<dd><a href="' . esc_url( $term_link ) . '">' . esc_html( $uc_term->name ) . '</a></dd>';
+					}
+				}
+				echo '</dl>';
+			}
+		}
+
+		// Display University tags attached to the post.
+		if ( has_tag() ) {
+			echo '<dl class="tagged">';
+			echo '<dt><span class="tagged-default">Tagged</span></dt>';
+			foreach ( get_the_tags() as $post_tag ) {
+				echo '<dd><a href="' . esc_url( get_tag_link( $post_tag->term_id ) ) . '">' . esc_html( $post_tag->name ) . '</a></dd>';
+			}
+			echo '</dl>';
+		}
+
+		// Display University locations attached to the post.
+		if ( taxonomy_exists( 'wsuwp_university_location' ) && has_term( '', 'wsuwp_university_location' ) ) {
+			$university_location_terms = get_the_terms( get_the_ID(), 'wsuwp_university_location' );
+			if ( ! is_wp_error( $university_location_terms ) ) {
+				echo '<dl class="university-location">';
+				echo '<dt><span class="university-location-default">Location</span></dt>';
+
+				foreach ( $university_location_terms as $ul_term ) {
+					$term_link = get_term_link( $ul_term->term_id, 'wsuwp_university_location' );
+					if ( ! is_wp_error( $term_link ) ) {
+						echo '<dd><a href="' . esc_url( $ul_term_link ) . '">' . esc_html( $ul_term->name ) . '</a></dd>';
+					}
+				}
+				echo '</dl>';
+			}
+		}
+
+		// If a user has filled out their description and this is a multi-author blog, show a bio on their entries.
+		if ( is_singular() && get_the_author_meta( 'description' ) && is_multi_author() ) : ?>
+		<div class="author-info">
+
+			<div class="author-avatar">
+				<?php
+				/** This filter is documented in author.php */
+				$author_bio_avatar_size = apply_filters( 'sfs411_author_bio_avatar_size', 68 );
+				echo get_avatar( get_the_author_meta( 'user_email' ), $author_bio_avatar_size );
+				?>
+			</div><!-- .author-avatar -->
+
+			<div class="author-description">
+				<h2><?php
+				/* translators: %s: author name */
+				printf( esc_html__( 'About %s', 'sfs411' ), get_the_author() );
+				?></h2>
+				<p><?php the_author_meta( 'description' ); ?></p>
+				<?php if ( '1' === spine_get_option( 'show_author_page' ) ) : ?>
+				<div class="author-link">
+					<a href="<?php echo esc_url( get_author_posts_url( get_the_author_meta( 'ID' ) ) ); ?>" rel="author">
+						<?php
+						/* translators: %s: author name */
+						printf( esc_html__( 'View all posts by %s', 'sfs411' ), get_the_author() );
+						?> <span class="meta-nav">&rarr;</span>
+					</a>
+				</div><!-- .author-link	-->
+				<?php endif; ?>
+			</div><!-- .author-description -->
+
+		</div><!-- .author-info -->
+	<?php endif; ?>
+
+	</footer><!-- .entry-meta -->
+
+</article>

--- a/comments.php
+++ b/comments.php
@@ -1,0 +1,121 @@
+<?php
+/**
+ * The template file for displaying the comments and comment form.
+ *
+ * Copied from the Twenty Twenty theme.
+ *
+ * @package sfs411
+ */
+
+/*
+ * If the current post is protected by a password and
+ * the visitor has not yet entered the password we will
+ * return early without loading the comments.
+*/
+if ( post_password_required() ) {
+	return;
+}
+
+if ( $comments ) {
+	$comments_number = absint( get_comments_number() );
+	?>
+
+	<div class="comments" id="comments">
+
+		<div class="comments-header">
+
+			<h2 class="comment-reply-title">
+			<?php
+			if ( ! have_comments() ) {
+				esc_html_e( 'Leave a comment', 'sfs411' );
+			} elseif ( '1' === $comments_number ) {
+				/* translators: %s: post title */
+				printf( esc_html_x( 'One reply on &ldquo;%s&rdquo;', 'comments title', 'sfs411' ), esc_html( get_the_title() ) );
+			} else {
+				echo esc_html(
+					sprintf(
+						/* translators: 1: number of comments, 2: post title */
+						_nx(
+							'%1$s reply on &ldquo;%2$s&rdquo;',
+							'%1$s replies on &ldquo;%2$s&rdquo;',
+							$comments_number,
+							'comments title',
+							'sfs411'
+						),
+						esc_html( number_format_i18n( $comments_number ) ),
+						esc_html( get_the_title() )
+					)
+				);
+			}
+
+			?>
+			</h2><!-- .comments-title -->
+
+		</div><!-- .comments-header -->
+
+		<div class="comments-inner section-inner thin max-percentage">
+
+			<?php
+			wp_list_comments(
+				array(
+					'avatar_size' => 0,
+					'style'       => 'div',
+					'format'      => 'html5',
+					'page'        => get_the_ID(),
+				)
+			);
+
+			$comment_pagination = paginate_comments_links(
+				array(
+					'echo'      => false,
+					'end_size'  => 0,
+					'mid_size'  => 0,
+					'next_text' => __( 'Newer Comments', 'sfs411' ) . ' <span aria-hidden="true">&rarr;</span>',
+					'prev_text' => '<span aria-hidden="true">&larr;</span> ' . __( 'Older Comments', 'sfs411' ),
+				)
+			);
+
+			if ( $comment_pagination ) {
+				$pagination_classes = '';
+
+				// If we're only showing the "Next" link, add a class indicating so.
+				if ( false === strpos( $comment_pagination, 'prev page-numbers' ) ) {
+					$pagination_classes = ' only-next';
+				}
+				?>
+
+				<nav class="comments-pagination pagination<?php echo $pagination_classes; //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- static output ?>" aria-label="<?php esc_attr_e( 'Comments', 'sfs411' ); ?>">
+					<?php echo wp_kses_post( $comment_pagination ); ?>
+				</nav>
+
+				<?php
+			}
+			?>
+
+		</div><!-- .comments-inner -->
+
+	</div><!-- comments -->
+
+	<?php
+}
+
+if ( comments_open() ) {
+
+	comment_form(
+		array(
+			'format' => 'html5',
+		)
+	);
+
+} elseif ( is_single() ) {
+
+	?>
+
+	<div class="comment-respond" id="respond">
+
+		<p class="comments-closed"><?php esc_html_e( 'Comments are closed.', 'sfs411' ); ?></p>
+
+	</div><!-- #respond -->
+
+	<?php
+}

--- a/comments.php
+++ b/comments.php
@@ -83,7 +83,7 @@ if ( $comments ) {
 				}
 				?>
 
-				<nav class="comments-pagination pagination<?php echo $pagination_classes; //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- static output ?>" aria-label="<?php esc_attr_e( 'Comments', 'sfs411' ); ?>">
+				<nav class="comments-pagination pagination<?php echo esc_attr( $pagination_classes ); ?>" aria-label="<?php esc_attr_e( 'Comments', 'sfs411' ); ?>">
 					<?php echo wp_kses_post( $comment_pagination ); ?>
 				</nav>
 

--- a/comments.php
+++ b/comments.php
@@ -60,7 +60,6 @@ if ( $comments ) {
 				array(
 					'avatar_size' => 0,
 					'style'       => 'div',
-					'format'      => 'html5',
 					'page'        => get_the_ID(),
 				)
 			);
@@ -101,11 +100,7 @@ if ( $comments ) {
 
 if ( comments_open() ) {
 
-	comment_form(
-		array(
-			'format' => 'html5',
-		)
-	);
+	comment_form();
 
 } elseif ( is_single() ) {
 

--- a/css/knowledge-base.css
+++ b/css/knowledge-base.css
@@ -1,0 +1,3 @@
+article.type-knowledge_base header time:before {
+	content: none;
+}

--- a/functions.php
+++ b/functions.php
@@ -10,3 +10,4 @@
 require_once 'includes/knowledge-base-post-type.php';
 require_once 'includes/comment-form.php';
 require_once 'includes/flagged-posts.php';
+require_once 'includes/stale-posts.php';

--- a/functions.php
+++ b/functions.php
@@ -9,3 +9,4 @@
 
 require_once 'includes/knowledge-base-post-type.php';
 require_once 'includes/comment-form.php';
+require_once 'includes/flagged-posts.php';

--- a/functions.php
+++ b/functions.php
@@ -7,6 +7,19 @@
  * @package sfs411
  */
 
+add_filter( 'spine_child_theme_version', 'sfs411_theme_version' );
+
+/**
+ * Provides a theme version for use in cache busting.
+ *
+ * @since 0.0.1
+ *
+ * @return string
+ */
+function sfs411_theme_version() {
+	return '0.0.1';
+}
+
 require_once 'includes/knowledge-base-post-type.php';
 require_once 'includes/comment-form.php';
 require_once 'includes/flagged-posts.php';

--- a/functions.php
+++ b/functions.php
@@ -6,3 +6,5 @@
  *
  * @package sfs411
  */
+
+require_once 'includes/knowledge-base-post-type.php';

--- a/functions.php
+++ b/functions.php
@@ -8,3 +8,4 @@
  */
 
 require_once 'includes/knowledge-base-post-type.php';
+require_once 'includes/comment-form.php';

--- a/includes/comment-form.php
+++ b/includes/comment-form.php
@@ -10,6 +10,7 @@ namespace SFS411\Comment\Form;
 add_action( 'after_setup_theme', __NAMESPACE__ . '\register_html5_support' );
 add_filter( 'comment_form_fields', __NAMESPACE__ . '\filter_comment_form_fields', 10 );
 add_filter( 'preprocess_comment', __NAMESPACE__ . '\preprocess_comment_data', 10 );
+
 /**
  * Registers HTML5 support for the comment form and comments output.
  */

--- a/includes/comment-form.php
+++ b/includes/comment-form.php
@@ -29,11 +29,13 @@ function register_html5_support() {
  * @return array $comment_fields A modified list of comment fields.
  */
 function filter_comment_form_fields( $comment_fields ) {
+	if ( 'knowledge_base' === get_post_type() ) {
 
-	// Add a checkbox for flagging that the comment is about bad content on the post.
-	$flag_checkbox = '<p class="comment-form-flag"><input type="checkbox" id="content-flag" name="content_flag" /><label for="content-flag">This post has old, missing, or incorrect content</label></p>';
+		// Add a checkbox for flagging that the comment is about bad content on the post.
+		$flag_checkbox = '<p class="comment-form-flag"><input type="checkbox" id="content-flag" name="content_flag" /><label for="content-flag">This post has old, missing, or incorrect content</label></p>';
 
-	$comment_fields['comment'] = $comment_fields['comment'] . $flag_checkbox;
+		$comment_fields['comment'] = $comment_fields['comment'] . $flag_checkbox;
+	}
 
 	return $comment_fields;
 }

--- a/includes/comment-form.php
+++ b/includes/comment-form.php
@@ -29,7 +29,7 @@ function register_html5_support() {
  * @return array $comment_fields A modified list of comment fields.
  */
 function filter_comment_form_fields( $comment_fields ) {
-	if ( 'knowledge_base' === get_post_type() ) {
+	if ( 'knowledge_base' === get_post_type() && is_user_logged_in() ) {
 
 		// Add a checkbox for flagging that the comment is about bad content on the post.
 		$flag_checkbox = '<p class="comment-form-flag"><input type="checkbox" id="content-flag" name="content_flag" /><label for="content-flag">This post has old, missing, or incorrect content</label></p>';

--- a/includes/comment-form.php
+++ b/includes/comment-form.php
@@ -8,7 +8,8 @@
 namespace SFS411\Comment\Form;
 
 add_action( 'after_setup_theme', __NAMESPACE__ . '\register_html5_support' );
-
+add_filter( 'comment_form_fields', __NAMESPACE__ . '\filter_comment_form_fields', 10 );
+add_filter( 'preprocess_comment', __NAMESPACE__ . '\preprocess_comment_data', 10 );
 /**
  * Registers HTML5 support for the comment form and comments output.
  */
@@ -17,4 +18,36 @@ function register_html5_support() {
 		'comment-form',
 		'comment-list',
 	) );
+}
+
+/**
+ * Add a checkbox to the comment form for flagging posts with bad content.
+ *
+ * @param array $comment_fields A list of comment fields to output when capturing a comment.
+ * @return array $comment_fields A modified list of comment fields.
+ */
+function filter_comment_form_fields( $comment_fields ) {
+
+	// Add a checkbox for flagging that the comment is about bad content on the post.
+	$flag_checkbox = '<p class="comment-form-flag"><input type="checkbox" id="content-flag" name="content_flag" /><label for="content-flag">This post has old, missing, or incorrect content</label></p>';
+
+	$comment_fields['comment'] = $comment_fields['comment'] . $flag_checkbox;
+
+	return $comment_fields;
+}
+
+/**
+ * If the comment is about bad content, save it as a `flagged_content` type.
+ *
+ * @param array $commentdata Submitted comment data.
+ * @return array $commentdata Modified comment data.
+ */
+function preprocess_comment_data( $commentdata ) {
+
+	// Nonce verification is not necessary for the comment form.
+	if ( is_user_logged_in() && isset( $_POST['content_flag'] ) ) { // phpcs:ignore WordPress.CSRF.NonceVerification.NoNonceVerification
+		$commentdata['comment_type'] = 'flagged_content';
+	}
+
+	return $commentdata;
 }

--- a/includes/comment-form.php
+++ b/includes/comment-form.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * Handling for customizations to the comment form.
+ *
+ * @package sfs411
+ */
+
+namespace SFS411\Comment\Form;
+
+add_action( 'after_setup_theme', __NAMESPACE__ . '\register_html5_support' );
+
+/**
+ * Registers HTML5 support for the comment form and comments output.
+ */
+function register_html5_support() {
+	add_theme_support( 'html5', array(
+		'comment-form',
+		'comment-list',
+	) );
+}

--- a/includes/comment-form.php
+++ b/includes/comment-form.php
@@ -10,6 +10,7 @@ namespace SFS411\Comment\Form;
 add_action( 'after_setup_theme', __NAMESPACE__ . '\register_html5_support' );
 add_filter( 'comment_form_fields', __NAMESPACE__ . '\filter_comment_form_fields', 10 );
 add_filter( 'preprocess_comment', __NAMESPACE__ . '\preprocess_comment_data', 10 );
+add_action( 'wp_enqueue_scripts', __NAMESPACE__ . '\enqueue_comment_reply_script' );
 
 /**
  * Registers HTML5 support for the comment form and comments output.
@@ -51,4 +52,13 @@ function preprocess_comment_data( $commentdata ) {
 	}
 
 	return $commentdata;
+}
+
+/**
+ * Enqueues the comment reply script if appropriate.
+ */
+function enqueue_comment_reply_script() {
+	if ( is_singular() && comments_open() && get_option( 'thread_comments' ) ) {
+		wp_enqueue_script( 'comment-reply' );
+	}
 }

--- a/includes/css/stale-content-meta-box.css
+++ b/includes/css/stale-content-meta-box.css
@@ -1,0 +1,3 @@
+#sfs411-staleness-management_options-note {
+	width: 100%;
+}

--- a/includes/flagged-posts.php
+++ b/includes/flagged-posts.php
@@ -110,12 +110,12 @@ function comment_row_actions( $actions, $comment ) {
 
 	// Return early if this is not the Flagged Posts page.
 	if ( ! is_flagged_posts_page() ) {
-		return;
+		return $actions;
 	}
 
 	// Return early if the comment is not of the `flagged_content` type.
 	if ( 'flagged_content' !== $comment->comment_type ) {
-		return;
+		return $actions;
 	}
 
 	// Unset `unapprove` and`approve` actions, not applicable in this case.

--- a/includes/flagged-posts.php
+++ b/includes/flagged-posts.php
@@ -456,7 +456,7 @@ function comment_post( $comment_id, $comment_approved, $comment_data ) {
 
 	$subject = 'Your SFS 411 Knowledge Base post was flagged for content';
 
-	$dashboard_url   = add_query_arg( 'comment_type', 'flagged_content', get_admin_url( 'edit-comments.php' ) );
+	$dashboard_url   = add_query_arg( 'comment_type', 'flagged_content', get_admin_url( null, 'edit-comments.php' ) );
 	$flag_dashboard  = esc_url( add_query_arg( 'id', absint( $comment_id ), $dashboard_url ) );
 	$post_flags_dash = esc_url( add_query_arg( 'p', absint( $post->ID ), $dashboard_url ) );
 

--- a/includes/flagged-posts.php
+++ b/includes/flagged-posts.php
@@ -121,9 +121,10 @@ function comment_row_actions( $actions, $comment ) {
 		return $actions;
 	}
 
-	// Unset `unapprove` and`approve` actions, not applicable in this case.
+	// Unset `unapprove`, `approve`, and `spam` actions.
 	unset( $actions['unapprove'] );
 	unset( $actions['approve'] );
+	unset( $actions['spam'] );
 
 	// Modify the default `reply` action to use as a "Resolve" button.
 	$actions['reply'] = sprintf(
@@ -264,7 +265,7 @@ function filter_comment_counts( $count, $post_id ) {
 /**
  * Modifies the status links for the Flagged Posts page.
  *
- * This removes the "Pending" and "Approved" links,
+ * This removes the "Pending", "Approved", and "Spam" links,
  * and fixes the count for the "Mine" link, since that doesn't
  * seem possible to do through the `wp_count_comments` filter.
  *
@@ -280,6 +281,7 @@ function flagged_posts_status_links( $status_links ) {
 
 	unset( $status_links['moderated'] );
 	unset( $status_links['approved'] );
+	unset( $status_links['spam'] );
 
 	$comments_query = new \WP_Comment_Query();
 

--- a/includes/flagged-posts.php
+++ b/includes/flagged-posts.php
@@ -12,6 +12,7 @@ add_filter( 'parent_file', __NAMESPACE__ . '\flagged_posts_parent_file' );
 add_filter( 'submenu_file', __NAMESPACE__ . '\flagged_posts_submenu_file' );
 add_action( 'adminmenu', __NAMESPACE__ . '\adminmenu' );
 add_filter( 'comment_row_actions', __NAMESPACE__ . '\comment_row_actions', 10, 2 );
+add_action( 'admin_head', __NAMESPACE__ . '\admin_head' );
 add_action( 'admin_footer', __NAMESPACE__ . '\admin_footer' );
 add_filter( 'preprocess_comment', __NAMESPACE__ . '\preprocess_comment_data' );
 add_action( 'pre_get_comments', __NAMESPACE__ . '\filter_comments_query' );
@@ -150,7 +151,26 @@ function comment_row_actions( $actions, $comment ) {
 }
 
 /**
- * Add a checkbox to the comment list table reply form for resolving flags.
+ * Hides the comment filters for the Flagged Posts page.
+ */
+function admin_head() {
+
+	// Return early if this is not the Flagged Posts page.
+	if ( ! is_flagged_posts_page() ) {
+		return;
+	}
+	?>
+	<style type="text/css">
+		#filter-by-comment-type,
+		#post-query-submit {
+			display: none;
+		}
+	</style>
+	<?php
+}
+
+/**
+ * Adds a checkbox to the comment list table reply form for resolving flags.
  */
 function admin_footer() {
 
@@ -424,7 +444,7 @@ function filter_bulk_actions( $actions ) {
 }
 
 /**
- * Disable default comment notifications for comments flagging bad content
+ * Disables default comment notifications for comments flagging bad content
  * or resolving bad content flags.
  *
  * @param bool $maybe_notify Whether to notify blog moderator/post author.
@@ -441,7 +461,7 @@ function disable_default_notification( $maybe_notify, $comment_id ) {
 }
 
 /**
- * Send an email when a comment flagging bad content is submitted.
+ * Sends an email when a comment flagging bad content is submitted.
  *
  * @param int        $comment_id       The comment ID.
  * @param int|string $comment_approved 1 if the comment is approved, 0 if not, 'spam' if spam.

--- a/includes/flagged-posts.php
+++ b/includes/flagged-posts.php
@@ -180,7 +180,8 @@ function admin_footer() {
 }
 
 /**
- * If the comment is about bad content, save it as a `flagged_content` type.
+ * If a comment reply is marked as a resolution for a bad content flag,
+ * update the parent comment type to `resolved`.
  *
  * @param array $commentdata Submitted comment data.
  * @return array $commentdata Modified comment data.

--- a/includes/flagged-posts.php
+++ b/includes/flagged-posts.php
@@ -439,7 +439,7 @@ function disable_default_notification( $maybe_notify, $comment_id ) {
 function comment_post( $comment_id, $comment_approved, $comment_data ) {
 
 	// Return early if the comment is not of the `flagged-content` type.
-	if ( 'flagged_content' !== $comment_data->comment_type ) {
+	if ( 'flagged_content' !== $comment_data['comment_type'] ) {
 		return;
 	}
 
@@ -448,7 +448,7 @@ function comment_post( $comment_id, $comment_approved, $comment_data ) {
 		return;
 	}
 
-	$post = get_post( $comment_data->comment_post_ID );
+	$post = get_post( $comment_data['comment_post_ID'] );
 
 	$author_id = $post->post_author;
 
@@ -461,9 +461,9 @@ function comment_post( $comment_id, $comment_approved, $comment_data ) {
 	$post_flags_dash = esc_url( add_query_arg( 'p', absint( $post->ID ), $dashboard_url ) );
 	$all_posts_flags = esc_url( add_query_arg( 'comment_status', 'my_posts', $dashboard_url ) );
 
-	$body  = '<p>The Knowledge Base post "' . get_the_title() . '" has been flagged for old, missing, or inaccurate content.</p>';
+	$body .= '<p>The Knowledge Base post "' . get_the_title( $post ) . '" has been flagged for old, missing, or inaccurate content.</p>';
 	$body .= '<p>Please review the concern at <a href="' . $flag_dashboard . '">' . $flag_dashboard . '</a>. It can be resolved by clicking the "Resolve" action beneath the comment.</p>';
-	$body .= '<p>View all flags on "' . get_the_title() . '" at <a href="' . $post_flags_dash . '">' . $post_flags_dash . '</a>.</p>';
+	$body .= '<p>View all flags on "' . get_the_title( $post ) . '" at <a href="' . $post_flags_dash . '">' . $post_flags_dash . '</a>.</p>';
 	$body .= '<p>View flags for all your posts at <a href="' . $all_posts_flags . '">' . $all_posts_flags . '</a>.</p>';
 
 	$headers = array( 'Content-Type: text/html; charset=UTF-8' );

--- a/includes/flagged-posts.php
+++ b/includes/flagged-posts.php
@@ -1,0 +1,95 @@
+<?php
+/**
+ * Handling for the Flagged Posts dashboard.
+ *
+ * @package sfs411
+ */
+
+namespace SFS411\Dashboard\Flagged_Content;
+
+add_action( 'admin_menu', __NAMESPACE__ . '\add_flagged_posts_page' );
+add_filter( 'parent_file', __NAMESPACE__ . '\flagged_posts_parent_file' );
+add_filter( 'submenu_file', __NAMESPACE__ . '\flagged_posts_submenu_file' );
+add_action( 'adminmenu', __NAMESPACE__ . '\adminmenu' );
+
+/**
+ * Adds the Flagged Posts page the the Knowledge Base menu.
+ */
+function add_flagged_posts_page() {
+	add_submenu_page(
+		'edit.php?post_type=knowledge_base',
+		'Flagged Posts',
+		'Flagged Posts',
+		'manage_options',
+		'edit-comments.php?comment_type=flagged_content&post_type=knowledge_base',
+		'',
+		1
+	);
+}
+
+/**
+ * Determines if the current page is the Flagged Posts page.
+ */
+function is_flagged_posts_page() {
+	if ( ! isset( $_GET['comment_type'] ) || 'flagged_content' !== $_GET['comment_type'] ) { // phpcs:ignore WordPress.CSRF.NonceVerification.NoNonceVerification
+		return false;
+	}
+
+	return true;
+}
+
+/**
+ * Filters the parent file of the Flagged Posts menu item.
+ *
+ * @param string $parent_file The parent file.
+ * @return string The parent file.
+ */
+function flagged_posts_parent_file( $parent_file ) {
+	if ( is_flagged_posts_page() ) {
+		$parent_file = 'edit.php?post_type=knowledge_base';
+	}
+
+	return $parent_file;
+}
+
+/**
+ * Filters the file of the Flagged Posts menu item.
+ *
+ * @param string $submenu_file The submenu file.
+ * @return string The submenu file.
+ */
+function flagged_posts_submenu_file( $submenu_file ) {
+	if ( is_flagged_posts_page() ) {
+		$submenu_file = 'edit-comments.php?comment_type=flagged_content&post_type=knowledge_base';
+	}
+
+	return $submenu_file;
+}
+
+/**
+ * Removes the `current` classes and aria attributes from the Comments menu
+ * item when Flagged Posts is the current page.
+ *
+ * Filtering the parent and submenu file doesn't take care of this,
+ * because the Flagged Posts page technically is the Comments page,
+ * presumably.
+ */
+function adminmenu() {
+	if ( ! is_flagged_posts_page() ) {
+		return;
+	}
+	?>
+	<script type="text/javascript">
+		function commentsMenuItem() {
+			const item = document.getElementById( 'menu-comments' );
+			const link = item.querySelector( 'a' );
+
+			item.classList.remove( 'current' );
+			link.classList.remove( 'current' );
+			link.removeAttribute( 'aria-current' );
+		};
+
+		commentsMenuItem();
+	</script>
+	<?php
+}

--- a/includes/flagged-posts.php
+++ b/includes/flagged-posts.php
@@ -160,6 +160,7 @@ function admin_footer() {
 	}
 	?>
 	<script type="text/javascript">
+		// Add a checkbox for marking a reply as a resolution of the content flag.
 		function addResolveCheckbox() {
 			const checkbox = document.createElement( 'input' );
 			const label = document.createElement( 'label' );
@@ -177,10 +178,20 @@ function admin_footer() {
 			replyContainer.appendChild( label );
 		};
 
+		// Remove the filter actions, except for the "Empty Trash" button.
 		function removeFilterActions() {
 			const filterActions = document.getElementById( 'filter-by-comment-type' ).parentNode;
 
-			filterActions.parentNode.removeChild( filterActions );
+			let child = filterActions.firstElementChild;
+
+			while ( child ) {
+				if ( 'delete_all' === child.id ) {
+					break;
+				}
+
+				filterActions.removeChild( child );
+				child = filterActions.firstElementChild;
+			}
 		}
 
 		addResolveCheckbox();

--- a/includes/flagged-posts.php
+++ b/includes/flagged-posts.php
@@ -27,7 +27,7 @@ function add_flagged_posts_page() {
 		'edit.php?post_type=knowledge_base',
 		'Flagged Posts',
 		'Flagged Posts',
-		'manage_options',
+		'moderate_comments',
 		'edit-comments.php?comment_type=flagged_content',
 		'',
 		1

--- a/includes/flagged-posts.php
+++ b/includes/flagged-posts.php
@@ -166,7 +166,14 @@ function admin_footer() {
 			replyContainer.appendChild( label );
 		};
 
+		function removeFilterActions() {
+			const filterActions = document.getElementById( 'filter-by-comment-type' ).parentNode;
+
+			filterActions.parentNode.removeChild( filterActions );
+		}
+
 		addResolveCheckbox();
+		removeFilterActions();
 	</script>
 	<?php
 }

--- a/includes/flagged-posts.php
+++ b/includes/flagged-posts.php
@@ -17,6 +17,7 @@ add_filter( 'preprocess_comment', __NAMESPACE__ . '\preprocess_comment_data' );
 add_action( 'pre_get_comments', __NAMESPACE__ . '\filter_comments_query' );
 add_filter( 'wp_count_comments', __NAMESPACE__ . '\filter_comment_counts', 10, 2 );
 add_filter( 'comment_status_links', __NAMESPACE__ . '\flagged_posts_status_links' );
+add_filter( 'bulk_actions-edit-comments', __NAMESPACE__ . '\filter_bulk_actions' );
 
 /**
  * Adds the Flagged Posts page the the Knowledge Base menu.
@@ -313,4 +314,25 @@ function flagged_posts_status_links( $status_links ) {
 	);
 
 	return $status_links;
+}
+
+/**
+ * Filters the bulk actions available on the Flagged Posts page.
+ *
+ * @param array $actions Array of default bulk actions.
+ * @return array Modified array of bulk actions.
+ */
+function filter_bulk_actions( $actions ) {
+
+	// Return early if this is not the Flagged Posts page.
+	if ( ! is_flagged_posts_page() ) {
+		return $actions;
+	}
+
+	// Remove the `unapprove`, `approve`, and `spam` bulk actions.
+	unset( $actions['unapprove'] );
+	unset( $actions['approve'] );
+	unset( $actions['spam'] );
+
+	return $actions;
 }

--- a/includes/flagged-posts.php
+++ b/includes/flagged-posts.php
@@ -459,10 +459,12 @@ function comment_post( $comment_id, $comment_approved, $comment_data ) {
 	$dashboard_url   = add_query_arg( 'comment_type', 'flagged_content', get_admin_url( null, 'edit-comments.php' ) );
 	$flag_dashboard  = esc_url( add_query_arg( 'id', absint( $comment_id ), $dashboard_url ) );
 	$post_flags_dash = esc_url( add_query_arg( 'p', absint( $post->ID ), $dashboard_url ) );
+	$all_posts_flags = esc_url( add_query_arg( 'comment_status', 'my_posts', $dashboard_url ) );
 
 	$body  = '<p>The Knowledge Base post "' . get_the_title() . '" has been flagged for old, missing, or inaccurate content.</p>';
 	$body .= '<p>Please review the concern at <a href="' . $flag_dashboard . '">' . $flag_dashboard . '</a>. It can be resolved by clicking the "Resolve" action beneath the comment.</p>';
-	$body .= '<p>View all flags on "' . get_the_title() . '": <a href="' . $post_flags_dash . '">' . $post_flags_dash . '</a>';
+	$body .= '<p>View all flags on "' . get_the_title() . '" at <a href="' . $post_flags_dash . '">' . $post_flags_dash . '</a>.</p>';
+	$body .= '<p>View flags for all your posts at <a href="' . $all_posts_flags . '">' . $all_posts_flags . '</a>.</p>';
 
 	$headers = array( 'Content-Type: text/html; charset=UTF-8' );
 

--- a/includes/flagged-posts.php
+++ b/includes/flagged-posts.php
@@ -78,6 +78,8 @@ function flagged_posts_submenu_file( $submenu_file ) {
  * presumably.
  */
 function adminmenu() {
+
+	// Return early if this is not the Flagged Posts page.
 	if ( ! is_flagged_posts_page() ) {
 		return;
 	}
@@ -99,23 +101,28 @@ function adminmenu() {
 
 /**
  * Removes the `unapprove` and `approve` row actions and repurposes `reply`
- * into a `resolve` action.
+ * for use as part of the resolution workflow.
  *
  * @param array      $actions Array of comment actions.
  * @param WP_Comment $comment The comment object.
  */
 function comment_row_actions( $actions, $comment ) {
+
+	// Return early if this is not the Flagged Posts page.
 	if ( ! is_flagged_posts_page() ) {
 		return;
 	}
 
+	// Return early if the comment is not of the `flagged_content` type.
 	if ( 'flagged_content' !== $comment->comment_type ) {
 		return;
 	}
 
+	// Unset `unapprove` and`approve` actions, not applicable in this case.
 	unset( $actions['unapprove'] );
 	unset( $actions['approve'] );
 
+	// Modify the default `reply` action to use as a "Resolve" button.
 	$actions['reply'] = sprintf(
 		'<button type="button" onclick="window.commentReply && commentReply.open(\'%s\',\'%s\');" class="vim-r button-link hide-if-no-js" aria-label="%s">%s</button>',
 		$comment->comment_ID,
@@ -131,6 +138,8 @@ function comment_row_actions( $actions, $comment ) {
  * Add a checkbox to the comment list table reply form for resolving flags.
  */
 function admin_footer() {
+
+	// Return early if this is not the Flagged Posts page.
 	if ( ! is_flagged_posts_page() ) {
 		return;
 	}
@@ -168,7 +177,6 @@ function preprocess_comment_data( $commentdata ) {
 
 	// Nonce verification is not necessary for the comment form.
 	if ( is_user_logged_in() && isset( $_POST['resolve_flag'] ) && isset( $commentdata['comment_parent'] ) ) { // phpcs:ignore WordPress.CSRF.NonceVerification.NoNonceVerification
-
 		wp_update_comment( array(
 			'comment_ID'   => $commentdata['comment_parent'],
 			'comment_type' => 'resolved',

--- a/includes/js/stale-content-meta-box.js
+++ b/includes/js/stale-content-meta-box.js
@@ -1,0 +1,30 @@
+const stalenessMetaBoxHandling = ( function() {
+	const resetButton              = document.getElementById( 'sfs411-staleness-settings_reset' );
+	const durationOptionsContainer = document.getElementById( 'sfs411-staleness-settings_duration-options' );
+	const durationOptions          = Array.prototype.slice.apply( durationOptionsContainer.querySelectorAll( 'input' ) );
+
+	/**
+	 * Toggles the display and `disabled` attributes of the duration options.
+	 *
+	 * @param {object} event The click event.
+	 */
+	function resetStaleness( event ) {
+		if ( event.target.classList.contains( 'cancel' ) ) {
+			durationOptionsContainer.classList.add( 'hidden' );
+			resetButton.classList.remove( 'cancel' );
+			resetButton.innerText = 'Reset';
+			durationOptions.forEach( ( option ) => {
+				option.setAttribute( 'disabled', '' );
+			} );
+		} else {
+			durationOptionsContainer.classList.remove( 'hidden' );
+			resetButton.classList.add( 'cancel' );
+			resetButton.innerText = 'Cancel';
+			durationOptions.forEach( ( option ) => {
+				option.removeAttribute( 'disabled' );
+			} );
+		}
+	}
+
+	resetButton.addEventListener( 'click', resetStaleness );
+} () );

--- a/includes/js/stale-content-meta-box.js
+++ b/includes/js/stale-content-meta-box.js
@@ -1,7 +1,8 @@
 const stalenessMetaBoxHandling = ( function() {
-	const resetButton              = document.getElementById( 'sfs411-staleness-settings_reset' );
-	const durationOptionsContainer = document.getElementById( 'sfs411-staleness-settings_duration-options' );
+	const durationOptionsContainer = document.getElementById( 'sfs411-staleness-management_options' );
 	const durationOptions          = Array.prototype.slice.apply( durationOptionsContainer.querySelectorAll( 'input' ) );
+	const resetNote                = document.getElementById( 'sfs411-staleness-management_options-note' );
+	const resetButton              = document.getElementById( 'sfs411-staleness-management_reset' );
 
 	/**
 	 * Toggles the display and `disabled` attributes of the duration options.
@@ -10,19 +11,25 @@ const stalenessMetaBoxHandling = ( function() {
 	 */
 	function resetStaleness( event ) {
 		if ( event.target.classList.contains( 'cancel' ) ) {
-			durationOptionsContainer.classList.add( 'hidden' );
 			resetButton.classList.remove( 'cancel' );
 			resetButton.innerText = 'Reset';
+
+			durationOptionsContainer.classList.add( 'hidden' );
 			durationOptions.forEach( ( option ) => {
 				option.setAttribute( 'disabled', '' );
 			} );
+
+			resetNote.setAttribute( 'disabled', '' );
 		} else {
-			durationOptionsContainer.classList.remove( 'hidden' );
 			resetButton.classList.add( 'cancel' );
 			resetButton.innerText = 'Cancel';
+
+			durationOptionsContainer.classList.remove( 'hidden' );
 			durationOptions.forEach( ( option ) => {
 				option.removeAttribute( 'disabled' );
 			} );
+
+			resetNote.removeAttribute( 'disabled' );
 		}
 	}
 

--- a/includes/knowledge-base-post-type.php
+++ b/includes/knowledge-base-post-type.php
@@ -19,6 +19,7 @@ function register_post_type() {
 		'labels'                 => array(
 			'name'               => _x( 'Knowledge Base', 'Post Type General Name', 'sfs411' ),
 			'singular_name'      => _x( 'Knowledge Base', 'Post Type Singular Name', 'pfmc-feature-set' ),
+			'all_items'          => __( 'All Posts', 'sfs411' ),
 		),
 		'description'           => '',
 		'public'                => true,

--- a/includes/knowledge-base-post-type.php
+++ b/includes/knowledge-base-post-type.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * Handling for the Knowledge Base post type.
+ *
+ * @package sfs411
+ */
+
+namespace SFS411\Post_Type\Knowledge_Base;
+
+add_action( 'init', __NAMESPACE__ . '\register_post_type' );
+
+/**
+ * Register the Knowledge Base post type.
+ */
+function register_post_type() {
+
+	$args = array(
+		'label'                  => __( 'Knowledge Base', 'sfs411' ),
+		'labels'                 => array(
+			'name'               => _x( 'Knowledge Base', 'Post Type General Name', 'sfs411' ),
+			'singular_name'      => _x( 'Knowledge Base', 'Post Type Singular Name', 'pfmc-feature-set' ),
+		),
+		'description'           => '',
+		'public'                => true,
+		'publicly_queryable'    => true,
+		'show_ui'               => true,
+		'delete_with_user'      => false,
+		'has_archive'           => true,
+		'show_in_menu'          => true,
+		'show_in_nav_menus'     => false,
+		'exclude_from_search'   => false,
+		'capability_type'       => 'post',
+		'map_meta_cap'          => true,
+		'hierarchical'          => false,
+		'query_var'             => true,
+		'menu_position'         => 5,
+		'menu_icon'             => 'dashicons-clipboard',
+		'show_in_rest'          => true,
+		'rewrite'               => array(
+			'slug'       => __( 'knowledge-base', 'sfs411' ),
+			'with_front' => false,
+		),
+		'supports'              => array(
+			'title',
+			'editor',
+			'author',
+			'comments',
+			'revisions',
+		),
+		'taxonomies'            => array(
+			'category',
+			'post_tag',
+		),
+	);
+
+	\register_post_type( 'knowledge_base', $args );
+}

--- a/includes/stale-posts.php
+++ b/includes/stale-posts.php
@@ -73,8 +73,6 @@ function get_stale_in_fields() {
 /**
  * Displays a meta box used to manage post staleness.
  *
- * @since 0.3.0
- *
  * @param \WP_Post $post
  */
 function display_staleness_management_meta_box( $post ) {
@@ -166,8 +164,6 @@ function enqueue_meta_box_assets( $hook_suffix ) {
 
 /**
  * Saves the meta for tracking the staleness of a post.
- *
- * @since 0.3.0
  *
  * @param int      $post_id
  * @param \WP_Post $post

--- a/includes/stale-posts.php
+++ b/includes/stale-posts.php
@@ -340,15 +340,14 @@ function filter_by_stale_posts( $query ) {
 		return;
 	}
 
-	$query->set(
-		'meta_query',
+	$query->set( 'post_status', 'publish' );
+
+	$query->set( 'meta_query', array(
 		array(
-			array(
-				'key'     => '_sfs411_stale_by',
-				'value'   => date( 'Y-m-d' ),
-				'compare' => '<=',
-				'type'    => 'DATE',
-			),
-		)
-	);
+			'key'     => '_sfs411_stale_by',
+			'value'   => date( 'Y-m-d' ),
+			'compare' => '<=',
+			'type'    => 'DATE',
+		),
+	) );
 }

--- a/includes/stale-posts.php
+++ b/includes/stale-posts.php
@@ -45,10 +45,6 @@ function stale_posts_submenu_file( $submenu_file ) {
 
 /**
  * Adds a meta box for managing post staleness.
- *
- * @since 0.3.0
- *
- * @param string $post_type
  */
 function add_meta_boxes() {
 	add_meta_box(

--- a/includes/stale-posts.php
+++ b/includes/stale-posts.php
@@ -84,20 +84,22 @@ function get_stale_in_fields() {
 function display_staleness_management_meta_box( $post ) {
 	$stale_in = get_post_meta( $post->ID, '_sfs411_stale_in', true );
 	$stale_by = get_post_meta( $post->ID, '_sfs411_stale_by', true );
+	$flagged  = $stale_in && $stale_by;
 
 	wp_nonce_field( 'sfs411_check_staleness_nonce', 'sfs411-staleness-nonce' );
 
-	$flagged = $stale_in && $stale_by;
-
 	if ( $flagged ) :
+		$message = ( date( 'Y-m-d' ) > $stale_by )
+			? 'This post has been marked as stale since '
+			: 'This post is set to be marked as stale on ';
 		?>
-		<p id="sfs411-staleness-settings_message">This post is set to be marked as stale on <?php echo esc_html( date( 'F j, Y', strtotime( $stale_by ) ) ); ?>.</p>
+		<p id="sfs411-staleness-management_message"><?php echo esc_html( $message . date( 'F j, Y', strtotime( $stale_by ) ) ); ?>.</p>
 		<?php
 	endif;
 	?>
 
 	<div
-		id="sfs411-staleness-settings_duration-options"
+		id="sfs411-staleness-management_options"
 		<?php if ( $flagged ) : ?>class="hidden"<?php endif; ?>
 	>
 
@@ -107,23 +109,35 @@ function display_staleness_management_meta_box( $post ) {
 		<p>
 			<input
 				type="radio"
-				id="<?php echo esc_attr( $id ); ?>"
+				id="sfs411-staleness-management_options-<?php echo esc_attr( $id ); ?>"
 				name="_sfs411_stale_in"
 				value="<?php echo esc_attr( $value ); ?>"
 				<?php
 				checked( $stale_in, $value );
 				disabled( $flagged );
 				?>
-
 			>
-			<label for="<?php echo esc_attr( $id ); ?>">in <?php echo esc_html( $value ); ?></label>
+			<label for="sfs411-staleness-management_options-<?php echo esc_attr( $id ); ?>">in <?php echo esc_html( $value ); ?></label>
 		</p>
 		<?php endforeach; ?>
 
+		<?php if ( empty( get_current_screen()->action ) ) : ?>
+			<p><label for="sfs411-staleness-management_options-note">Leave a brief note explaining why this post is no longer stale (optional):</label></p>
+			<textarea
+				id="sfs411-staleness-management_options-note"
+				name="_sfs411_reset_note"
+				<?php disabled( $flagged ); ?>
+			></textarea>
+		<?php endif; ?>
+
 	</div>
 
-	<?php if ( $flagged ) : ?>
-		<button id="sfs411-staleness-settings_reset" class="components-button is-link">Reset</button>
+	<?php
+	if ( $flagged ) :
+		?>
+
+		<button id="sfs411-staleness-management_reset" class="components-button is-link">Reset</button>
+
 		<?php
 	endif;
 }

--- a/includes/stale-posts.php
+++ b/includes/stale-posts.php
@@ -9,6 +9,8 @@ namespace SFS411\Dashboard\Stale_Content;
 
 add_action( 'admin_menu', __NAMESPACE__ . '\add_stale_posts_page' );
 add_filter( 'submenu_file', __NAMESPACE__ . '\stale_posts_submenu_file' );
+add_action( 'add_meta_boxes_knowledge_base', __NAMESPACE__ . '\\add_meta_boxes' );
+add_action( 'save_post_knowledge_base', __NAMESPACE__ . '\\save_post', 10, 2 );
 
 /**
  * Adds the Stale Posts page the the Knowledge Base menu.
@@ -37,4 +39,109 @@ function stale_posts_submenu_file( $submenu_file ) {
 	}
 
 	return $submenu_file;
+}
+
+/**
+ * Adds a meta box for managing post staleness.
+ *
+ * @since 0.3.0
+ *
+ * @param string $post_type
+ */
+function add_meta_boxes() {
+	add_meta_box(
+		'sfs411-staleness-management',
+		'Staleness Management',
+		__NAMESPACE__ . '\display_staleness_management_meta_box',
+		'knowledge_base',
+		'side',
+		'high'
+	);
+}
+
+/**
+ * Returns an array of field values keyed by id.
+ *
+ * @return array Field values keyed by id.
+ */
+function get_stale_in_fields() {
+	return array(
+		'half-year' => '6 months',
+		'year'      => '1 year',
+	);
+}
+
+/**
+ * Displays a meta box used to manage post staleness.
+ *
+ * @since 0.3.0
+ *
+ * @param \WP_Post $post
+ */
+function display_staleness_management_meta_box( $post ) {
+	$stale_in = get_post_meta( $post->ID, '_sfs411_stale_in', true );
+	$stale_by = get_post_meta( $post->ID, '_sfs411_stale_by', true );
+
+	wp_nonce_field( 'sfs411_check_staleness_nonce', 'sfs411-staleness-nonce' );
+
+	if ( $stale_in && $stale_by ) :
+		?>
+			<p>This post is set to be marked as stale on <?php echo esc_html( date( 'F j, Y', strtotime( $stale_by ) ) ); ?>.
+		<?php
+	endif;
+
+	?>
+
+	<p>Mark this post as stale:</p>
+
+	<?php foreach ( get_stale_in_fields() as $id => $value ) : ?>
+	<p>
+		<input
+			type="radio"
+			id="<?php echo esc_attr( $id ); ?>"
+			name="_sfs411_stale_in"
+			value="<?php echo esc_attr( $value ); ?>"
+			<?php checked( $stale_in, $value ); ?>
+		>
+		<label for="half-year">in <?php echo esc_html( $value ); ?></label>
+	</p>
+	<?php endforeach; ?>
+
+	<?php
+}
+
+/**
+ * Saves the meta for tracking the staleness of a post.
+ *
+ * @since 0.3.0
+ *
+ * @param int      $post_id
+ * @param \WP_Post $post
+ */
+function save_post( $post_id, $post ) {
+	if ( ! isset( $_POST['sfs411-staleness-nonce'] ) || ! wp_verify_nonce( $_POST['sfs411-staleness-nonce'], 'sfs411_check_staleness_nonce' ) ) {
+		return;
+	}
+
+	if ( ! current_user_can( 'edit_post', $post_id ) ) {
+		return;
+	}
+
+	if ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) {
+		return;
+	}
+
+	if ( 'auto-draft' === $post->post_status ) {
+		return;
+	}
+
+	if ( isset( $_POST['_sfs411_stale_in'] ) && in_array( $_POST['_sfs411_stale_in'], array_values( get_stale_in_fields() ), true ) ) {
+
+		// Get the current date and modify it by the `_sfs411_stale_in` value.
+		$date = new \DateTime();
+		$stale_by = $date->modify( '+' . $_POST['_sfs411_stale_in'] )->format( 'Y-m-d' );
+
+		update_post_meta( $post_id, '_sfs411_stale_by', $stale_by );
+		update_post_meta( $post_id, '_sfs411_stale_in', $_POST['_sfs411_stale_in'] );
+	}
 }

--- a/includes/stale-posts.php
+++ b/includes/stale-posts.php
@@ -67,8 +67,9 @@ function add_meta_boxes() {
  */
 function get_stale_in_fields() {
 	return array(
-		'half-year' => '6 months',
-		'year'      => '1 year',
+		'quarterly'  => '3 months',
+		'biannually' => '6 months',
+		'annually'   => '1 year',
 	);
 }
 

--- a/includes/stale-posts.php
+++ b/includes/stale-posts.php
@@ -113,7 +113,6 @@ function stale_post_views( $views ) {
 
 	// Replace the default count with the stale posts by the current user.
 	$views['mine'] = preg_replace(
-		//'/\([^)]+\)/',
 		'/\(\d+\)/',
 		'(' . $users_stale_posts_count . ')',
 		$views['mine']

--- a/includes/stale-posts.php
+++ b/includes/stale-posts.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * Handling for the Stale Posts dashboard.
+ *
+ * @package sfs411
+ */
+
+namespace SFS411\Dashboard\Stale_Content;
+
+add_action( 'admin_menu', __NAMESPACE__ . '\add_stale_posts_page' );
+add_filter( 'submenu_file', __NAMESPACE__ . '\stale_posts_submenu_file' );
+
+/**
+ * Adds the Stale Posts page the the Knowledge Base menu.
+ */
+function add_stale_posts_page() {
+	add_submenu_page(
+		'edit.php?post_type=knowledge_base',
+		'Stale Posts',
+		'Stale Posts',
+		'manage_options',
+		'edit.php?post_type=knowledge_base&stale',
+		'',
+		2
+	);
+}
+
+/**
+ * Filters the file of the Stale Posts menu item.
+ *
+ * @param string $submenu_file The submenu file.
+ * @return string The submenu file.
+ */
+function stale_posts_submenu_file( $submenu_file ) {
+	if ( 'edit-knowledge_base' === get_current_screen()->id && isset( $_GET['stale'] ) ) { // phpcs:ignore WordPress.CSRF.NonceVerification.NoNonceVerification
+		$submenu_file = 'edit.php?post_type=knowledge_base&stale';
+	}
+
+	return $submenu_file;
+}

--- a/includes/stale-posts.php
+++ b/includes/stale-posts.php
@@ -10,7 +10,7 @@ namespace SFS411\Dashboard\Stale_Content;
 add_action( 'admin_menu', __NAMESPACE__ . '\add_stale_posts_page' );
 add_filter( 'submenu_file', __NAMESPACE__ . '\stale_posts_submenu_file' );
 add_action( 'add_meta_boxes_knowledge_base', __NAMESPACE__ . '\add_meta_boxes' );
-add_action( 'admin_enqueue_scripts', __NAMESPACE__ . '\enqueue_meta_box_script' );
+add_action( 'admin_enqueue_scripts', __NAMESPACE__ . '\enqueue_meta_box_assets' );
 add_action( 'save_post_knowledge_base', __NAMESPACE__ . '\save_post', 10, 2 );
 add_filter( 'pre_get_posts', __NAMESPACE__ . '\filter_by_stale_posts' );
 
@@ -147,16 +147,25 @@ function display_staleness_management_meta_box( $post ) {
  *
  * @param string $hook_suffix The current admin page
  */
-function enqueue_meta_box_script( $hook_suffix ) {
-	if ( 'post.php' === $hook_suffix && 'knowledge_base' === get_current_screen()->id ) {
-		wp_enqueue_script(
-			'sfs411-stale-content',
-			get_stylesheet_directory_uri() . '/includes/js/stale-content-meta-box.js',
-			array(),
-			spine_get_child_version(),
-			true
-		);
+function enqueue_meta_box_assets( $hook_suffix ) {
+	if ( 'post.php' !== $hook_suffix || 'knowledge_base' !== get_current_screen()->id ) {
+		return;
 	}
+
+	wp_enqueue_script(
+		'sfs411-stale-content',
+		get_stylesheet_directory_uri() . '/includes/js/stale-content-meta-box.js',
+		array(),
+		spine_get_child_version(),
+		true
+	);
+
+	wp_enqueue_style(
+		'sfs411-stale-content',
+		get_stylesheet_directory_uri() . '/includes/css/stale-content-meta-box.css',
+		array(),
+		spine_get_child_version()
+	);
 }
 
 /**

--- a/includes/stale-posts.php
+++ b/includes/stale-posts.php
@@ -395,7 +395,7 @@ function send_email() {
 				'post_type' => 'knowledge_base',
 				'stale'     => true,
 				'author'    => get_current_user_id(),
-			), get_admin_url( 'edit.php' ) ) );
+			), get_admin_url( null, 'edit.php' ) ) );
 
 			$body  = '<p>The Knowledge Base post "' . get_the_title() . '" has been scheduled for review.</p>';
 			$body .= '<p>Please make any necessary changes at <a href="' . $edit_post . '">' . $edit_post . '</a>, then use the "Reset" button in the "Staleness Management" box to schedule the next time the post should be reviewed.<p>';

--- a/includes/stale-posts.php
+++ b/includes/stale-posts.php
@@ -22,7 +22,7 @@ function add_stale_posts_page() {
 		'edit.php?post_type=knowledge_base',
 		'Stale Posts',
 		'Stale Posts',
-		'manage_options',
+		'edit_posts',
 		'edit.php?post_type=knowledge_base&stale',
 		'',
 		2

--- a/includes/stale-posts.php
+++ b/includes/stale-posts.php
@@ -184,15 +184,37 @@ function save_post( $post_id, $post ) {
 		return;
 	}
 
-	if ( isset( $_POST['_sfs411_stale_in'] ) && in_array( $_POST['_sfs411_stale_in'], array_values( get_stale_in_fields() ), true ) ) {
-
-		// Get the current date and modify it by the `_sfs411_stale_in` value.
-		$date = new \DateTime();
-		$stale_by = $date->modify( '+' . $_POST['_sfs411_stale_in'] )->format( 'Y-m-d' );
-
-		update_post_meta( $post_id, '_sfs411_stale_by', $stale_by );
-		update_post_meta( $post_id, '_sfs411_stale_in', $_POST['_sfs411_stale_in'] );
+	if ( ! isset( $_POST['_sfs411_stale_in'] ) || ! in_array( $_POST['_sfs411_stale_in'], array_values( get_stale_in_fields() ), true ) ) {
+		return;
 	}
+
+	update_post_meta( $post_id, '_sfs411_stale_in', $_POST['_sfs411_stale_in'] );
+
+	// Get the current date and modify it by the `_sfs411_stale_in` value.
+	$date = new \DateTime();
+	$stale_by = $date->modify( '+' . $_POST['_sfs411_stale_in'] )->format( 'Y-m-d' );
+
+	update_post_meta( $post_id, '_sfs411_stale_by', $stale_by );
+
+	// Get existing reset log meta.
+	$reset_log = get_post_meta( $post_id, '_sfs411_reset_log', true );
+	$reset_log = ( $reset_log ) ? $reset_log : array();
+
+	// Set up user and date of the current reset.
+	$this_reset = array(
+		'user' => wp_get_current_user()->user_login,
+		'date' => date( 'm-d-Y' ),
+	);
+
+	// Add the note for the current reset if there is one.
+	if ( isset( $_POST['_sfs411_reset_note'] ) ) {
+		$this_reset['note'] = sanitize_text_field( $_POST['_sfs411_reset_note'] );
+	}
+
+	// Append the current reset to the log.
+	$reset_log[] = $this_reset;
+
+	update_post_meta( $post_id, '_sfs411_reset_log', $reset_log );
 }
 
 /**

--- a/includes/stale-posts.php
+++ b/includes/stale-posts.php
@@ -11,6 +11,7 @@ add_action( 'admin_menu', __NAMESPACE__ . '\add_stale_posts_page' );
 add_filter( 'submenu_file', __NAMESPACE__ . '\stale_posts_submenu_file' );
 add_filter( 'views_edit-knowledge_base', __NAMESPACE__ . '\stale_post_views' );
 add_filter( 'bulk_actions-edit-knowledge_base', __NAMESPACE__ . '\filter_bulk_actions' );
+add_filter( 'post_row_actions', __NAMESPACE__ . '\post_row_actions', 10, 2 );
 add_action( 'add_meta_boxes_knowledge_base', __NAMESPACE__ . '\add_meta_boxes' );
 add_action( 'admin_enqueue_scripts', __NAMESPACE__ . '\enqueue_meta_box_assets' );
 add_action( 'save_post_knowledge_base', __NAMESPACE__ . '\save_post', 10, 2 );
@@ -129,6 +130,21 @@ function stale_post_views( $views ) {
  */
 function filter_bulk_actions( $actions ) {
 	if ( is_stale_posts_page() ) {
+		unset( $actions['trash'] );
+	}
+
+	return $actions;
+}
+
+/**
+ * Removes row actions that are not relevant to the Stale Posts dashboard.
+ *
+ * @param array   $actions Array of row action links.
+ * @param WP_Post $post    The post object.
+ */
+function post_row_actions( $actions, $post ) {
+	if ( 'knowledge_base' === $post->post_type && is_stale_posts_page() ) {
+		unset( $actions['inline hide-if-no-js'] );
 		unset( $actions['trash'] );
 	}
 

--- a/single-knowledge_base.php
+++ b/single-knowledge_base.php
@@ -1,0 +1,83 @@
+<?php
+/**
+ * Template for displaying a Knowledge Base post's layout.
+ *
+ * @package sfs411
+ */
+
+get_header();
+
+do_action( 'spine_theme_template_before_main', 'single-knowledge-base.php' );
+
+?>
+
+<main id="wsuwp-main">
+
+	<?php
+
+	do_action( 'spine_theme_template_before_headers', 'single-knowledge-base.php' );
+
+	wsuwp_spine_get_template_part( 'single-knowledge-base.php', 'parts/headers' );
+
+	do_action( 'spine_theme_template_after_headers', 'single-knowledge-base.php' );
+
+	do_action( 'spine_theme_template_before_content', 'single-knowledge-base.php' );
+
+	if ( spine_has_featured_image() && 'page' !== get_post_type() ) {
+		$featured_image_src = spine_get_featured_image_src();
+		$featured_image_position = get_post_meta( get_the_ID(), '_featured_image_position', true );
+
+		if ( ! $featured_image_position || sanitize_html_class( $featured_image_position ) !== $featured_image_position ) {
+			$featured_image_position = '';
+		}
+		?><figure class="featured-image <?php echo sanitize_html_class( $featured_image_position ); ?>" style="background-image: url('<?php echo esc_url( $featured_image_src ); ?>');"><?php spine_the_featured_image(); ?></figure><?php
+	}
+
+	?>
+
+	<section class="row side-right gutter pad-ends">
+
+		<div class="column one">
+
+			<?php while ( have_posts() ) : the_post(); ?>
+
+				<?php get_template_part( 'articles/post', get_post_type() ) ?>
+
+			<?php endwhile; ?>
+
+		</div><!--/column-->
+
+		<div class="column two"></div><!--/column two-->
+
+	</section>
+
+	<footer class="main-footer">
+		<section class="row halves pager prevnext gutter pad-ends">
+			<div class="column one">
+				<?php previous_post_link(); ?>
+			</div>
+			<div class="column two">
+				<?php next_post_link(); ?>
+			</div>
+		</section><!--pager-->
+	</footer>
+
+	<?php
+
+	do_action( 'spine_theme_template_after_content', 'single-knowledge-base.php' );
+
+	do_action( 'spine_theme_template_before_footer', 'single-knowledge-base.php' );
+
+	wsuwp_spine_get_template_part( 'single-knowledge-base.php', 'parts/footers' );
+
+	do_action( 'spine_theme_template_after_footer', 'single-knowledge-base.php' );
+
+	?>
+
+</main><!--/#page-->
+
+<?php
+
+do_action( 'spine_theme_template_after_main', 'single-knowledge-base.php' );
+
+get_footer();

--- a/style.css
+++ b/style.css
@@ -7,4 +7,8 @@
  Template:       spine
  Version:        0.0.1
 */
+
+article.type-knowledge_base header time:before {
+	content: none;
+}
 /*# sourceMappingURL=style.css.map */


### PR DESCRIPTION
* Registers the knowledge base post type.
* Introduces templates for the knowledge base post type.
* Introduces a comments template.
* Introduces a workflow for managing bad content on knowledge base posts:
  * adds a checkbox to the comment form for flagging posts with bad content;
  * saves comments about bad content as a `flagged_content` comment type;
  * adds a dashboard page for displaying `flagged_content` comments;
  * modifies status links, bulk actions, and row actions on the `flagged_content` dashboard;
  * repurposes the `reply` row action for use in resolving flagged content comments;
  * emails the post author when a post is commented on with the `flagged_content` type.
* Introduces a workflow for managing stale content on knowledge base posts:
  * adds a meta box for setting/resetting a duration after which to mark the post as stale;
  * adds a dashboard page for displaying stale posts;
  * modifies view links, bulk actions, and row actions on the stale posts dashboard;
  * emails the post author when a post has gone stale.